### PR TITLE
Jdl/pde 1622 worldpay host change

### DIFF
--- a/cnp_chargeback.gemspec
+++ b/cnp_chargeback.gemspec
@@ -6,7 +6,7 @@ require 'version'
 
 Gem::Specification.new do |spec|
   spec.name = 'CnpChargeback'
-  spec.version = CnpChargeback::VERSION
+  spec.version = '2.1'
   spec.authors = ['Micki Balder']
   spec.email = ['micki.balder@food52.com']
   spec.summary = 'Food52 Forked version of CnpChargeback from Vantiv/WorldPay'

--- a/cnp_chargeback.gemspec
+++ b/cnp_chargeback.gemspec
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+lib = File.expand_path('lib', __dir__)
+$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
+require 'version'
+
+Gem::Specification.new do |spec|
+  spec.name = 'CnpChargeback'
+  spec.version = CnpChargeback::VERSION
+  spec.authors = ['Micki Balder']
+  spec.email = ['micki.balder@food52.com']
+  spec.summary = 'Food52 Forked version of CnpChargeback from Vantiv/WorldPay'
+  spec.description = 'A wrapper for the Vantiv/WorldPay CnpChargeback API'
+  spec.homepage = 'https://github.com/food52/cnp-chargeback-sdk-ruby'
+  spec.platform = Gem::Platform::RUBY
+  spec.license = 'MIT'
+
+  spec.files = Dir['**/**']
+  spec.executables = ['sample_driver.rb', 'Setup.rb']
+  spec.test_files = Dir['test/unit/ts_unit.rb']
+
+  spec.add_dependency('xml-object')
+  spec.add_dependency('xml-mapping')
+  spec.add_dependency('mimemagic')
+  spec.add_dependency('net-sftp')
+  spec.add_dependency('libxml-ruby')
+  spec.add_dependency('crack')
+  spec.add_dependency('iostreams')
+  spec.add_development_dependency('mocha')
+end

--- a/lib/ChargebackDocument.rb
+++ b/lib/ChargebackDocument.rb
@@ -27,7 +27,7 @@ require_relative 'Configuration'
 #
 # This class handles sending the Cnp online request
 #
-module CnpOnline
+module CnpChargeback
 
   class ChargebackDocument
     def initialize

--- a/lib/ChargebackDocument.rb
+++ b/lib/ChargebackDocument.rb
@@ -30,8 +30,8 @@ require_relative 'Configuration'
 module CnpChargeback
 
   class ChargebackDocument
-    def initialize
-      @config_hash = Configuration.new.config
+    def initialize(config_hash = {})
+      @config_hash = Configuration.new.config.merge(config_hash)
     end
 
     def retrieve_document(case_id:, document_id:, document_path:, config: @config_hash)

--- a/lib/ChargebackRetrieval.rb
+++ b/lib/ChargebackRetrieval.rb
@@ -27,7 +27,7 @@ require_relative 'Configuration'
 #
 # This class handles sending the Cnp online request
 #
-module CnpOnline
+module CnpChargeback
 
   class ChargebackRetrieval
     def initialize

--- a/lib/ChargebackRetrieval.rb
+++ b/lib/ChargebackRetrieval.rb
@@ -30,8 +30,8 @@ require_relative 'Configuration'
 module CnpChargeback
 
   class ChargebackRetrieval
-    def initialize
-      @config_hash = Configuration.new.config
+    def initialize(config_hash = {})
+      @config_hash = Configuration.new.config.merge(config_hash)
     end
 
     def get_chargebacks_by_date(activity_date:, config: @config_hash)

--- a/lib/ChargebackUpdate.rb
+++ b/lib/ChargebackUpdate.rb
@@ -27,7 +27,7 @@ require_relative 'Configuration'
 #
 # This class handles sending the Cnp online request
 #
-module CnpOnline
+module CnpChargeback
 
   class ChargebackUpdate
     def initialize

--- a/lib/ChargebackUpdate.rb
+++ b/lib/ChargebackUpdate.rb
@@ -30,8 +30,8 @@ require_relative 'Configuration'
 module CnpChargeback
 
   class ChargebackUpdate
-    def initialize
-      @config_hash = Configuration.new.config
+    def initialize(config_hash = {})
+      @config_hash = Configuration.new.config.merge(config_hash)
     end
 
     def assign_case_to_user(case_id:, user_id:, note:, config: @config_hash)

--- a/lib/Communications.rb
+++ b/lib/Communications.rb
@@ -263,10 +263,9 @@ module CnpChargeback
 
     def self.write_document(http_response, document_path, config_hash)
       content_type = http_response.content_type
-      if content_type != "image/tiff"
-        raise ("Wrong response content type")
-      end
-    else
+      
+      raise ("Wrong response content type") if content_type != "image/tiff"
+
       open(document_path, "wb") do |file|
         file.write(http_response.body)
       end

--- a/lib/Communications.rb
+++ b/lib/Communications.rb
@@ -203,6 +203,7 @@ module CnpChargeback
 
       req = Net::HTTP::Get.new(url, CHARGEBACK_API_HEADERS)
       req.basic_auth(config_hash['user'], config_hash['password'])
+      req = set_request_headers_host(req)
 
       logger.debug "GET request to: " + url.to_s + "\n"
 
@@ -296,6 +297,18 @@ module CnpChargeback
       logger.formatter = proc { |severity, datetime, progname, msg| "#{msg}\n" }
       logger
     end
+
+    def self.set_request_headers_host(req)
+      req_headers = req.instance_variable_get('@header')
+      if !Rails.env.production?
+        req_headers["host"] = ["services.vantivprelive.com:443"]
+      else
+        req_headers["host"] = ["services.vantivcnp.com:443"]
+      end
+      req.instance_variable_set('@header', req_headers)
+      req
+    end
+
   end
 end
 

--- a/lib/Communications.rb
+++ b/lib/Communications.rb
@@ -43,11 +43,12 @@ module CnpOnline
       url = URI.parse(request_url)
       logger = initialize_logger(config_hash)
       http_response = nil
+      ssl_verify_mode = config_hash['ssl_verify_mode'] || OpenSSL::SSL::VERIFY_PEER
 
       https = Net::HTTP.new(url.host, url.port, proxy_addr, proxy_port)
       if url.scheme == 'https'
         https.use_ssl = url.scheme=='https'
-        https.verify_mode = OpenSSL::SSL::VERIFY_PEER
+        https.verify_mode = ssl_verify_mode
         https.ca_file = File.join(File.dirname(__FILE__), "cacert.pem")
       end
 
@@ -71,11 +72,12 @@ module CnpOnline
       url = URI.parse(request_url)
       logger = initialize_logger(config_hash)
       http_response = nil
+      ssl_verify_mode = config_hash['ssl_verify_mode'] || OpenSSL::SSL::VERIFY_PEER
 
       https = Net::HTTP.new(url.host, url.port, proxy_addr, proxy_port)
       if url.scheme == 'https'
         https.use_ssl = url.scheme=='https'
-        https.verify_mode = OpenSSL::SSL::VERIFY_PEER
+        https.verify_mode = ssl_verify_mode
         https.ca_file = File.join(File.dirname(__FILE__), "cacert.pem")
       end
 
@@ -100,11 +102,12 @@ module CnpOnline
       url = URI.parse(request_url)
       logger = initialize_logger(config_hash)
       http_response = nil
+      ssl_verify_mode = config_hash['ssl_verify_mode'] || OpenSSL::SSL::VERIFY_PEER
 
       https = Net::HTTP.new(url.host, url.port, proxy_addr, proxy_port)
       if url.scheme == 'https'
         https.use_ssl = url.scheme=='https'
-        https.verify_mode = OpenSSL::SSL::VERIFY_PEER
+        https.verify_mode = ssl_verify_mode
         https.ca_file = File.join(File.dirname(__FILE__), "cacert.pem")
       end
 
@@ -130,11 +133,12 @@ module CnpOnline
       url = URI.parse(request_url)
       logger = initialize_logger(config_hash)
       http_response = nil
+      ssl_verify_mode = config_hash['ssl_verify_mode'] || OpenSSL::SSL::VERIFY_PEER
 
       https = Net::HTTP.new(url.host, url.port, proxy_addr, proxy_port)
       if url.scheme == 'https'
         https.use_ssl = url.scheme=='https'
-        https.verify_mode = OpenSSL::SSL::VERIFY_PEER
+        https.verify_mode = ssl_verify_mode
         https.ca_file = File.join(File.dirname(__FILE__), "cacert.pem")
       end
 
@@ -160,11 +164,12 @@ module CnpOnline
       url = URI.parse(request_url)
       logger = initialize_logger(config_hash)
       http_response = nil
+      ssl_verify_mode = config_hash['ssl_verify_mode'] || OpenSSL::SSL::VERIFY_PEER
 
       https = Net::HTTP.new(url.host, url.port, proxy_addr, proxy_port)
       if url.scheme == 'https'
         https.use_ssl = url.scheme=='https'
-        https.verify_mode = OpenSSL::SSL::VERIFY_PEER
+        https.verify_mode = ssl_verify_mode
         https.ca_file = File.join(File.dirname(__FILE__), "cacert.pem")
       end
 
@@ -187,11 +192,12 @@ module CnpOnline
       url = URI.parse(request_url)
       logger = initialize_logger(config_hash)
       http_response = nil
+      ssl_verify_mode = config_hash['ssl_verify_mode'] || OpenSSL::SSL::VERIFY_PEER
 
       https = Net::HTTP.new(url.host, url.port, proxy_addr, proxy_port)
       if url.scheme == 'https'
         https.use_ssl = url.scheme=='https'
-        https.verify_mode = OpenSSL::SSL::VERIFY_PEER
+        https.verify_mode = ssl_verify_mode
         https.ca_file = File.join(File.dirname(__FILE__), "cacert.pem")
       end
 
@@ -215,11 +221,12 @@ module CnpOnline
       url = URI.parse(request_url)
       logger = initialize_logger(config_hash)
       http_response = nil
+      ssl_verify_mode = config_hash['ssl_verify_mode'] || OpenSSL::SSL::VERIFY_PEER
 
       https = Net::HTTP.new(url.host, url.port, proxy_addr, proxy_port)
       if url.scheme == 'https'
         https.use_ssl = url.scheme=='https'
-        https.verify_mode = OpenSSL::SSL::VERIFY_PEER
+        https.verify_mode = ssl_verify_mode
         https.ca_file = File.join(File.dirname(__FILE__), "cacert.pem")
       end
 

--- a/lib/Communications.rb
+++ b/lib/Communications.rb
@@ -30,7 +30,7 @@ OTHER DEALINGS IN THE SOFTWARE.
 # URL and proxy server settings are derived from the configuration file
 #
 
-module CnpOnline
+module CnpChargeback
   class Communications
     CHARGEBACK_API_HEADERS = {'Accept' => 'application/com.vantivcnp.services-v2+xml',
                                'Content-Type' => 'application/com.vantivcnp.services-v2+xml'}

--- a/lib/Configuration.rb
+++ b/lib/Configuration.rb
@@ -27,7 +27,7 @@ require_relative 'EnvironmentVariables'
 #
 # Loads the configuration from a file
 #
-module CnpOnline
+module CnpChargeback
   class Configuration
     class << self
       # External logger, if specified

--- a/lib/EnvironmentVariables.rb
+++ b/lib/EnvironmentVariables.rb
@@ -1,4 +1,4 @@
-module CnpOnline
+module CnpChargeback
   class EnvironmentVariables
     def initialize
       # load configuration data

--- a/lib/XMLFields.rb
+++ b/lib/XMLFields.rb
@@ -23,7 +23,7 @@ OTHER DEALINGS IN THE SOFTWARE.
 # Contains all of the underlying XML fields and specifications needed to create the transaction set
 #
 
-module CnpOnline
+module CnpChargeback
   class UpdateRequest
     include XML::Mapping
     root_element_name "chargebackUpdateRequest"

--- a/lib/version.rb
+++ b/lib/version.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+module CnpChargeback
+  VERSION = '2.1'
+end

--- a/test/functional/test_chargeback_document.rb
+++ b/test/functional/test_chargeback_document.rb
@@ -25,7 +25,7 @@ OTHER DEALINGS IN THE SOFTWARE.
 require File.expand_path("../../../lib/CnpChargeback", __FILE__)
 require 'test/unit'
 
-module CnpOnline
+module CnpChargeback
   class TestChargebackUpdate < Test::Unit::TestCase
     def setup
       @package_root = Dir.pwd

--- a/test/functional/test_chargeback_retrieval.rb
+++ b/test/functional/test_chargeback_retrieval.rb
@@ -25,7 +25,7 @@ OTHER DEALINGS IN THE SOFTWARE.
 require File.expand_path("../../../lib/CnpChargeback", __FILE__)
 require 'test/unit'
 
-module CnpOnline
+module CnpChargeback
   class TestChargebackRetrieval < Test::Unit::TestCase
 
     def test_activity_date

--- a/test/functional/test_chargeback_update.rb
+++ b/test/functional/test_chargeback_update.rb
@@ -25,7 +25,7 @@ OTHER DEALINGS IN THE SOFTWARE.
 require File.expand_path("../../../lib/CnpChargeback", __FILE__)
 require 'test/unit'
 
-module CnpOnline
+module CnpChargeback
   class TestChargebackUpdate < Test::Unit::TestCase
 
     def test_assign_case_to_user


### PR DESCRIPTION
As per https://food52.atlassian.net/browse/PDE-1622

Changing request headers `host` to use `services.vantivcnp.com` / `services.vantivprelive.com` for Worldpay. 